### PR TITLE
fix local entrypoint code

### DIFF
--- a/evo2-backend/requirements.txt
+++ b/evo2-backend/requirements.txt
@@ -1,3 +1,4 @@
+fastapi[standard]
 modal
 matplotlib
 pandas


### PR DESCRIPTION
fixes a few things when trying to run `modal run main.py`
* need to explicitly include fastapi in the image build now
* you can't call `remote` explicitly on a web endpoint, so i adapted `main` to be a simple requests example (does require `requests` to be installed locally which is maybe a little annoying)

